### PR TITLE
added 2 new options to remove additional C# keywords before parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "csharp2ts",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "csharp2ts",
     "displayName": "CSharp2TS",
     "description": "Convert C# POCOs to typescript",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "publisher": "rafaelsalguero",
     "repository": {
         "type": "git",
@@ -101,6 +101,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "True to preserve fields and property modifiers. Default is false"
+                },
+                "csharp2ts.removeSpecialKeywords": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True to remove special keywords virtual and #nullable disable"
+                },
+                "csharp2ts.removeUsings": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "True to remove using/import statements"
                 }
             }
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,10 @@ export interface ExtensionConfig {
     classToInterface: boolean;
     /**True to preserve fields and property modifiers. Default is false */
     preserveModifiers: boolean;
+    /**True to remove special keywords virtual and #nullable disable */
+    removeSpecialKeywords: boolean;
+    /**True to remove imports/using statements */
+    removeUsings: boolean;
 }
 
 export const maxBodyDepth = 8;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,9 +119,25 @@ function findMatch(code: string, startIndex: number, config: ExtensionConfig): M
     } : null;
 }
 
+function removeSpecialKeywords(code: string): string {
+    return code.replace(/\s+virtual\s+/g, ' ').replace(/#nullable\s*(disable|enable)\s*\n/g,'');
+}
+
+function removeUsings(code: string): string {
+    return code.replace(/using\s+[^;]+;\s*\n/g, '');
+}
+
 /**Convert c# code to typescript code */
 export function cs2ts(code: string, config: ExtensionConfig): string {
     var ret = "";
+
+    if (config.removeSpecialKeywords) {
+        code = removeSpecialKeywords(code);
+    }
+
+    if (config.removeUsings) {
+        code = removeUsings(code);
+    }
 
     var index = 0;
     while (true) {
@@ -190,6 +206,8 @@ function getConfiguration(): ExtensionConfig {
     const removeNameRegex = vscode.workspace.getConfiguration('csharp2ts').get("removeNameRegex") as string;
     const classToInterface = vscode.workspace.getConfiguration('csharp2ts').get("classToInterface") as boolean;
     const preserveModifiers = vscode.workspace.getConfiguration('csharp2ts').get("preserveModifiers") as boolean;
+    const removeSpecialKeywords = vscode.workspace.getConfiguration('csharp2ts').get("removeSpecialKeywords") as boolean;
+    const removeUsings = vscode.workspace.getConfiguration('csharp2ts').get("removeUsings") as boolean;
 
     return {
         propertiesToCamelCase,
@@ -204,7 +222,9 @@ function getConfiguration(): ExtensionConfig {
         removeWithModifier,
         removeNameRegex,
         classToInterface,
-        preserveModifiers
+        preserveModifiers,
+        removeSpecialKeywords,
+        removeUsings
     };
 }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -27,7 +27,9 @@ suite("Extension Tests", () => {
             removeWithModifier: ["private", "internal"],
             removeNameRegex: "_[a-z][a-zA-Z0-9]*",
             classToInterface: true,
-            preserveModifiers: false
+            preserveModifiers: false,
+            removeSpecialKeywords: true,
+            removeUsings: true
         };
         const testPairs: { inputs: string[], output: string }[] = [
             {
@@ -68,7 +70,9 @@ suite("Extension Tests", () => {
             removeWithModifier: [],
             removeNameRegex: "",
             classToInterface: true,
-            preserveModifiers: false
+            preserveModifiers: false,
+            removeSpecialKeywords: true,
+            removeUsings: true
         };
 
         const testPairs: { inputs: string[], output: string }[] = [
@@ -149,7 +153,9 @@ suite("Extension Tests", () => {
             removeWithModifier: [],
             removeNameRegex: "",
             classToInterface: true,
-            preserveModifiers: false
+            preserveModifiers: false,
+            removeSpecialKeywords: true,
+            removeUsings: true
         };
 
         const testPairs: { inputs: string[], output: string }[] = [


### PR DESCRIPTION
Hi,
I've added 2 new options (off by default) to remove additional keywords like **virtual** and **using** statements. This was very helpfull for me as I had a lot of auto generated C# classes which nearly all of them contained virtual properties.

I accidentally added the increased version number to the commit.