### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On your workspace or user `settings.json`:
 ```js
 // Place your settings in this file to overwrite default and user settings.
 {
-    //True for camelCase, false for preserving original name. Default is true
+    //True for camelCase, false for preserving original name. Default is false
     "csharp2ts.propertiesToCamelCase": false,
     //Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive.
     "csharp2ts.trimPostfixes": "",


### PR DESCRIPTION
upon fresh install in VSCode, he will use PascalCase. You need to explicitely set that property to true for it to be camelcase.