### PR TITLE
Added option to convert C# Dictionary into Typescript Record

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ On your workspace or user `settings.json`:
 - New config: removeUsings Remove using/import statements. Thanks @supermaz
 
 ### 0.0.27
-- New config: dictionaryToRecord Convert `Dictionary` to `Record`. Thanks @corwindickey
+- New config: dictionaryToRecord Convert `Dictionary` to `Record`. Thanks @CorwinDickey

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # csharp2ts README
 
 **How to use**
+
 - Select the desired C# code
 - Open the command pallete and run `Convert C# to TypeScript`
 
@@ -9,46 +10,52 @@
 Simple C# POCOs to TypeScript converter.
 
 Supports:
+
 - Automatic properties
 - Remove attributes
-- Detect common types such as int, long, ... 
+- Detect common types such as int, long, ...
 
 ## Settings
+
 On your workspace or user `settings.json`:
 
 ```js
 // Place your settings in this file to overwrite default and user settings.
 {
-    //True for camelCase, false for preserving original name. Default is false
+    /** True for camelCase, false for preserving original name. Default is false */
     "csharp2ts.propertiesToCamelCase": false,
-    //Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive.
+    /** Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive. */
     "csharp2ts.trimPostfixes": "",
-    //Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true)
+    /** Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
     "csharp2ts.recursiveTrimPostfixes": false,
-    //Ignore property initializer    
+    /** Ignore property initializer     */
     "csharp2ts.ignoreInitializer": true
-    //True to remove method bodies, false to preserve the body as-is
-     "csharp2ts.removeMethodBodies": true,
-     //True to remove class constructors, false to treat then like any other method
-     "csharp2ts.removeConstructors": false,
-     //'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller
-     "csharp2ts.methodStyle": 'signature',
-     //True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string
-     "csharp2ts.byteArrayToString": true,
-     //"True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string"s
-     "csharp2ts.dateToDateOrString": true,
-     /*Modifiers to remove. Ex. if you want to remove private and internal members set to ['private', 'internal']*/
-     "csharp2ts.removeModifiers": [],
-     /*If setted, any property or field that its name matches the given regex will be removed, Ex. if you want to remove backing fields starting with underscore set to "_[a-z][a-zA-Z0-9]*" */
-     "csharp2ts.removeNameRegex": "",
-     /*True to convert classes to interfaces, false to convert classes to classes. Default is true*/
-     "csharp2ts.classToInterface": true,
-     /*True to preserve fields and property modifiers. Default is false*/
-     "csharp2ts.preserveModifiers": false
+    /** True to remove method bodies, false to preserve the body as-is */
+    "csharp2ts.removeMethodBodies": true,
+    /** True to remove class constructors, false to treat then like any other method */
+    "csharp2ts.removeConstructors": false,
+    /** 'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller */
+    "csharp2ts.methodStyle": 'signature',
+    /** True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string */
+    "csharp2ts.byteArrayToString": true,
+    /** True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string */
+    "csharp2ts.dateToDateOrString": true,
+    /** Modifiers to remove. Ex. if you want to remove private and internal members set to ['private', 'internal'] */
+    "csharp2ts.removeModifiers": [],
+    /** If setted, any property or field that its name matches the given regex will be removed, Ex. if you want to remove backing fields starting with underscore set to "_[a-z][a-zA-Z0-9]*" */
+    "csharp2ts.removeNameRegex": "",
+    /** True to convert classes to interfaces, false to convert classes to classes. Default is true */
+    "csharp2ts.classToInterface": true,
+    /** True to preserve fields and property modifiers. Default is false */
+    "csharp2ts.preserveModifiers": false
+    /** True to convert a C# dictionary into a typescript Record instead of { [key: t]: V }. Default is false */
+    "dictionaryToRecord": false;
+
 }
 ```
 
 ## Release Notes
+
 ### 0.0.0
 
 - Initial release of the tool
@@ -68,17 +75,22 @@ On your workspace or user `settings.json`:
 - Added detection for scope modifiers on C# properties
 
 ### 0.0.6
+
 ### 0.0.7
+
 - Fixed readme animation
 
 ### 0.0.8
+
 - Bug fix: Automatic properties without any visibility modifiers where skipping line jumps
 
 ### 0.0.9
+
 - Support for the 'new' modifier on automatic properties
 - Support for C# fat arrow automatic properties
 
 ### 0.0.10
+
 - Full C# type parser
 - Support for C# generics
 - Support for nullable types: Convert `int?` or `Nullable<int>` to `int | null`
@@ -87,26 +99,33 @@ On your workspace or user `settings.json`:
 - Convert C# `List<T>` to `T[]`
 
 ### 0.0.11
+
 - Bug fix: Getter only properties where not correctly parsed
 
 ### 0.0.12
+
 - Support for cammelCase/PascalCase. Configurable with the `"csharp2ts.propertiesToCamelCase"` setting
 
 ### 0.0.13
+
 - Documentation for settings added
 
 ### 0.0.14
+
 - new `trimPostfixes` and `recursiveTrimPostfixes` config. Thanks amadare42
 
 ### 0.0.15
+
 - `csharp2ts.propertiesToCamelCase` is set to `false` by default
 
 ### 0.0.16
+
 - Bug fix: Property initializer correctly parsed
 - New `csharp2ts.ignoreInitializer` config
 - `double` correctly parsed
 
 ### 0.0.17
+
 - Support method and constructor signature conversion and body removing
 - Emit method signature or method empty implementation, see the `csharp2ts.methodStyle` configuration
 - Added a C# XML Docs parser, improving generated JSDoc
@@ -114,32 +133,49 @@ On your workspace or user `settings.json`:
 - Support for the `Task` type
 
 ### 0.0.18
+
 - Bug fix: Support for international characters on identifiers
 
 ### 0.0.19
+
 - Bug fix: Support for international characters on type names
 
 #### 0.0.20
+
 - Improved attribute parsing and removing
 - New method body style `controller`
 
 #### 0.0.21
+
 - Improved class constructor parsing
 - New configuration for type generators: `byteArrayToString` and `dateToDateOrString`
 
 #### 0.0.22
+
 - Bug fix: Support for fields
 - Bug fix: Translation was wrong on some special cases with generic types mixed with arrays
 - New config: `classToInterface`. Convert `class` to `interface` or `class`
-- New config: `preserveModifiers`. Preserve properties and field modifiers. 
+- New config: `preserveModifiers`. Preserve properties and field modifiers.
 - New config: `removeWithModifier`. Remove fields and properties with the given modifiers.
 - New config: `removeNameRegex`. Remove fields and properties that its name match the given regex.
 
 #### 0.0.23
+
 - Improved parsing for `partial` classes and multiple inheritances
 
 #### 0.0.24
+
 - Bug fix: Incorrectly parsed generic type on certain conditions. Thanks @labarilem
 
 #### 0.0.25
+
 - Support for C# 9
+
+### 0.0.26
+
+- New config: removeSpecialKeywords Remove virtual and #nullable statements. Thanks @supermaz
+- New config: removeUsings Remove using/import statements. Thanks @supermaz
+
+### 0.0.27
+
+- New config: dictionaryToRecord Convert `Dictionary` to `Record`. Thanks @corwindickey

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # csharp2ts README
 
 **How to use**
-
 - Select the desired C# code
 - Open the command pallete and run `Convert C# to TypeScript`
 
@@ -10,13 +9,11 @@
 Simple C# POCOs to TypeScript converter.
 
 Supports:
-
 - Automatic properties
 - Remove attributes
 - Detect common types such as int, long, ...
 
 ## Settings
-
 On your workspace or user `settings.json`:
 
 ```js
@@ -55,7 +52,6 @@ On your workspace or user `settings.json`:
 ```
 
 ## Release Notes
-
 ### 0.0.0
 
 - Initial release of the tool
@@ -75,22 +71,17 @@ On your workspace or user `settings.json`:
 - Added detection for scope modifiers on C# properties
 
 ### 0.0.6
-
 ### 0.0.7
-
 - Fixed readme animation
 
 ### 0.0.8
-
 - Bug fix: Automatic properties without any visibility modifiers where skipping line jumps
 
 ### 0.0.9
-
 - Support for the 'new' modifier on automatic properties
 - Support for C# fat arrow automatic properties
 
 ### 0.0.10
-
 - Full C# type parser
 - Support for C# generics
 - Support for nullable types: Convert `int?` or `Nullable<int>` to `int | null`
@@ -99,33 +90,26 @@ On your workspace or user `settings.json`:
 - Convert C# `List<T>` to `T[]`
 
 ### 0.0.11
-
 - Bug fix: Getter only properties where not correctly parsed
 
 ### 0.0.12
-
 - Support for cammelCase/PascalCase. Configurable with the `"csharp2ts.propertiesToCamelCase"` setting
 
 ### 0.0.13
-
 - Documentation for settings added
 
 ### 0.0.14
-
 - new `trimPostfixes` and `recursiveTrimPostfixes` config. Thanks amadare42
 
 ### 0.0.15
-
 - `csharp2ts.propertiesToCamelCase` is set to `false` by default
 
 ### 0.0.16
-
 - Bug fix: Property initializer correctly parsed
 - New `csharp2ts.ignoreInitializer` config
 - `double` correctly parsed
 
 ### 0.0.17
-
 - Support method and constructor signature conversion and body removing
 - Emit method signature or method empty implementation, see the `csharp2ts.methodStyle` configuration
 - Added a C# XML Docs parser, improving generated JSDoc
@@ -133,25 +117,20 @@ On your workspace or user `settings.json`:
 - Support for the `Task` type
 
 ### 0.0.18
-
 - Bug fix: Support for international characters on identifiers
 
 ### 0.0.19
-
 - Bug fix: Support for international characters on type names
 
 #### 0.0.20
-
 - Improved attribute parsing and removing
 - New method body style `controller`
 
 #### 0.0.21
-
 - Improved class constructor parsing
 - New configuration for type generators: `byteArrayToString` and `dateToDateOrString`
 
 #### 0.0.22
-
 - Bug fix: Support for fields
 - Bug fix: Translation was wrong on some special cases with generic types mixed with arrays
 - New config: `classToInterface`. Convert `class` to `interface` or `class`
@@ -160,22 +139,17 @@ On your workspace or user `settings.json`:
 - New config: `removeNameRegex`. Remove fields and properties that its name match the given regex.
 
 #### 0.0.23
-
 - Improved parsing for `partial` classes and multiple inheritances
 
 #### 0.0.24
-
 - Bug fix: Incorrectly parsed generic type on certain conditions. Thanks @labarilem
 
 #### 0.0.25
-
 - Support for C# 9
 
 ### 0.0.26
-
 - New config: removeSpecialKeywords Remove virtual and #nullable statements. Thanks @supermaz
 - New config: removeUsings Remove using/import statements. Thanks @supermaz
 
 ### 0.0.27
-
 - New config: dictionaryToRecord Convert `Dictionary` to `Record`. Thanks @corwindickey

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ On your workspace or user `settings.json`:
     "csharp2ts.trimPostfixes": "",
     /** Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
     "csharp2ts.recursiveTrimPostfixes": false,
-    /** Ignore property initializer     */
+    /** Ignore property initializer */
     "csharp2ts.ignoreInitializer": true
     /** True to remove method bodies, false to preserve the body as-is */
     "csharp2ts.removeMethodBodies": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface ExtensionConfig {
   recursiveTrimPostfixes: boolean;
   /**ignoreInitializer */
   ignoreInitializer: boolean;
-  /** True to remove method bodies, false to preserve the body as-is*/
+  /**True to remove method bodies, false to preserve the body as-is */
   removeMethodBodies: boolean;
   /**True to remove class constructors, false to treat then like any other method */
   removeConstructors: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,35 +1,36 @@
-
 export interface ExtensionConfig {
-    /**True for camelCase, false for preserving original name */
-    propertiesToCamelCase: boolean;
-    /**Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive. */
-    trimPostfixes: string[];
-    /**Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
-    recursiveTrimPostfixes: boolean;
-    /**ignoreInitializer */
-    ignoreInitializer: boolean;
-    /** True to remove method bodies, false to preserve the body as-is*/
-    removeMethodBodies: boolean;
-    /**True to remove class constructors, false to treat then like any other method */
-    removeConstructors: boolean;
-    /**'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller */
-    methodStyle: "signature" | "lambda" | "controller";
-    /**True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string */
-    byteArrayToString: boolean;
-    /**True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string */
-    dateToDateOrString: boolean;
-    /**Remove fields or properties with the given modifiers. Ex. if you want to remove private and internal members set to ['private', 'internal'] */
-    removeWithModifier: string[];
-    /**If setted, any property or field that its name matches the given regex will be removed */
-    removeNameRegex: string;
-    /**True to convert classes to interfaces, false to convert classes to classes. Default is true */
-    classToInterface: boolean;
-    /**True to preserve fields and property modifiers. Default is false */
-    preserveModifiers: boolean;
-    /**True to remove special keywords virtual and #nullable disable */
-    removeSpecialKeywords: boolean;
-    /**True to remove imports/using statements */
-    removeUsings: boolean;
+  /**True for camelCase, false for preserving original name */
+  propertiesToCamelCase: boolean;
+  /**Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive. */
+  trimPostfixes: string[];
+  /**Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
+  recursiveTrimPostfixes: boolean;
+  /**ignoreInitializer */
+  ignoreInitializer: boolean;
+  /** True to remove method bodies, false to preserve the body as-is*/
+  removeMethodBodies: boolean;
+  /**True to remove class constructors, false to treat then like any other method */
+  removeConstructors: boolean;
+  /**'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller */
+  methodStyle: "signature" | "lambda" | "controller";
+  /**True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string */
+  byteArrayToString: boolean;
+  /**True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string */
+  dateToDateOrString: boolean;
+  /**Remove fields or properties with the given modifiers. Ex. if you want to remove private and internal members set to ['private', 'internal'] */
+  removeWithModifier: string[];
+  /**If setted, any property or field that its name matches the given regex will be removed */
+  removeNameRegex: string;
+  /**True to convert classes to interfaces, false to convert classes to classes. Default is true */
+  classToInterface: boolean;
+  /**True to preserve fields and property modifiers. Default is false */
+  preserveModifiers: boolean;
+  /**True to remove special keywords virtual and #nullable disable */
+  removeSpecialKeywords: boolean;
+  /**True to remove imports/using statements */
+  removeUsings: boolean;
+  /**True to convert a C# dictionary into a typescript Record instead of { [key: t]: V }. Default is false */
+  dictionaryToRecord: boolean;
 }
 
 export const maxBodyDepth = 8;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,36 +1,36 @@
 export interface ExtensionConfig {
-  /**True for camelCase, false for preserving original name */
-  propertiesToCamelCase: boolean;
-  /**Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive. */
-  trimPostfixes: string[];
-  /**Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
-  recursiveTrimPostfixes: boolean;
-  /**ignoreInitializer */
-  ignoreInitializer: boolean;
-  /**True to remove method bodies, false to preserve the body as-is */
-  removeMethodBodies: boolean;
-  /**True to remove class constructors, false to treat then like any other method */
-  removeConstructors: boolean;
-  /**'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller */
-  methodStyle: "signature" | "lambda" | "controller";
-  /**True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string */
-  byteArrayToString: boolean;
-  /**True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string */
-  dateToDateOrString: boolean;
-  /**Remove fields or properties with the given modifiers. Ex. if you want to remove private and internal members set to ['private', 'internal'] */
-  removeWithModifier: string[];
-  /**If setted, any property or field that its name matches the given regex will be removed */
-  removeNameRegex: string;
-  /**True to convert classes to interfaces, false to convert classes to classes. Default is true */
-  classToInterface: boolean;
-  /**True to preserve fields and property modifiers. Default is false */
-  preserveModifiers: boolean;
-  /**True to remove special keywords virtual and #nullable disable */
-  removeSpecialKeywords: boolean;
-  /**True to remove imports/using statements */
-  removeUsings: boolean;
-  /**True to convert a C# dictionary into a typescript Record instead of { [key: t]: V }. Default is false */
-  dictionaryToRecord: boolean;
+    /**True for camelCase, false for preserving original name */
+    propertiesToCamelCase: boolean;
+    /**Removes specified postfixes from property names, types & class names. Can be array OR string. Case-sensitive. */
+    trimPostfixes: string[];
+    /**Whether or not trim postfixes recursive. (e.g. with postfixes 'A' & 'B' PersonAAB will become PersonAA when it's false & Person when it's true) */
+    recursiveTrimPostfixes: boolean;
+    /**ignoreInitializer */
+    ignoreInitializer: boolean;
+    /**True to remove method bodies, false to preserve the body as-is */
+    removeMethodBodies: boolean;
+    /**True to remove class constructors, false to treat then like any other method */
+    removeConstructors: boolean;
+    /**'signature' to emit a method signature, 'lambda' to emit a lambda function. 'controller' to emit a lambda to call an async controller */
+    methodStyle: "signature" | "lambda" | "controller";
+    /**True to convert C# byte array type to Typescript string, defaults to true since the serialization of C# byte[] results in a string */
+    byteArrayToString: boolean;
+    /**True to convert C# DateTime and DateTimeOffset to Typescript (Date | string), defaults to true since the serialization of C# DateTime results in a string */
+    dateToDateOrString: boolean;
+    /**Remove fields or properties with the given modifiers. Ex. if you want to remove private and internal members set to ['private', 'internal'] */
+    removeWithModifier: string[];
+    /**If setted, any property or field that its name matches the given regex will be removed */
+    removeNameRegex: string;
+    /**True to convert classes to interfaces, false to convert classes to classes. Default is true */
+    classToInterface: boolean;
+    /**True to preserve fields and property modifiers. Default is false */
+    preserveModifiers: boolean;
+    /**True to remove special keywords virtual and #nullable disable */
+    removeSpecialKeywords: boolean;
+    /**True to remove imports/using statements */
+    removeUsings: boolean;
+    /**True to convert a C# dictionary into a typescript Record instead of { [key: t]: V }. Default is false */
+    dictionaryToRecord: boolean;
 }
 
 export const maxBodyDepth = 8;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,423 +1,334 @@
-import {
-  any,
-  cap,
-  nonCap,
-  oneOrMore,
-  optional,
-  seq,
-  zeroOrMore,
-} from "./compose";
-import {
-  identifier,
-  namespace as namespaceRegex,
-  space,
-  spaceOptional,
-} from "./regexs";
+import { any, cap, nonCap, oneOrMore, optional, seq, zeroOrMore } from "./compose";
+import { identifier, namespace as namespaceRegex, space, spaceOptional } from "./regexs";
 import { ExtensionConfig } from "./config";
 
 enum CsTypeCategory {
-  /**A type that can be represented as a collection of items */
-  Enumerable,
-  /**A dictionary is equivalent to a typescript object */
-  Dictionary,
-  /**A c$# nullable type where the value type is the first generic type */
-  Nullable,
-  /**A c# tuple */
-  Tuple,
-  /**A boolean type */
-  Boolean,
-  /**A numeric type */
-  Number,
-  /**A 1-dimension byte array */
-  ByteArray,
-  /**A date type */
-  Date,
-  /**A string type */
-  String,
-  /**Any type */
-  Any,
-  /**Unidentified type */
-  Other,
-  /**Task/promise task */
-  Task,
+    /**A type that can be represented as a collection of items */
+    Enumerable,
+    /**A dictionary is equivalent to a typescript object */
+    Dictionary,
+    /**A c$# nullable type where the value type is the first generic type */
+    Nullable,
+    /**A c# tuple */
+    Tuple,
+    /**A boolean type */
+    Boolean,
+    /**A numeric type */
+    Number,
+    /**A 1-dimension byte array */
+    ByteArray,
+    /**A date type */
+    Date,
+    /**A string type */
+    String,
+    /**Any type */
+    Any,
+    /**Unidentified type */
+    Other,
+    /**Task/promise task */
+    Task,
 }
 
 export interface CsType {
-  /**Type namespace */
-  namespace: string;
-  /**Type name */
-  name: string;
-  /**Generic arguments */
-  generics: CsType[];
+    /**Type namespace */
+    namespace: string;
+    /**Type name */
+    name: string;
+    /**Generic arguments */
+    generics: CsType[];
 
-  /**Neasted arrays */
-  array: CsArray[];
+    /**Nested arrays */
+    array: CsArray[];
 }
 
 /**Check if the given type is a simple that that passes as an uri parameter */
 export function isUriSimpleType(x: CsType): boolean {
-  const simpleCats: CsTypeCategory[] = [
-    CsTypeCategory.Boolean,
-    CsTypeCategory.Number,
-    CsTypeCategory.Date,
-    CsTypeCategory.String,
-  ];
+    const simpleCats: CsTypeCategory[] = [
+        CsTypeCategory.Boolean,
+        CsTypeCategory.Number,
+        CsTypeCategory.Date,
+        CsTypeCategory.String,
+    ];
 
-  const isSimpleCat = (x: CsTypeCategory) => simpleCats.indexOf(x) != -1;
-  const typeCat = getTypeCategory(x);
-  if (isSimpleCat(typeCat)) {
-    return true;
-  } else if (
-    typeCat == CsTypeCategory.Nullable &&
-    isSimpleCat(getTypeCategory(x.generics[0]))
-  ) {
-    return true;
-  }
-  return false;
+    const isSimpleCat = (x: CsTypeCategory) => simpleCats.indexOf(x) != -1;
+    const typeCat = getTypeCategory(x);
+    if (isSimpleCat(typeCat)) {
+        return true;
+    } else if (typeCat == CsTypeCategory.Nullable && isSimpleCat(getTypeCategory(x.generics[0]))) {
+        return true;
+    }
+    return false;
 }
 
 export function getTypeCategory(x: CsType): CsTypeCategory {
-  type TypeCategory = {
-    category: CsTypeCategory;
-    types: string[];
-    genericMin: number;
-    genericMax: number;
-  };
-  const byteTypeName = ["byte", "Byte", "System.Byte"];
+    type TypeCategory = {
+        category: CsTypeCategory;
+        types: string[];
+        genericMin: number;
+        genericMax: number;
+    };
+    const byteTypeName = ["byte", "Byte", "System.Byte"];
 
-  //Check if the type is byteArray
-  if (
-    byteTypeName.indexOf(x.name) != -1 &&
-    x.generics.length == 0 &&
-    x.array.length == 1 &&
-    x.array[0].dimensions == 1
-  ) {
-    return CsTypeCategory.ByteArray;
-  }
+    //Check if the type is byteArray
+    if (byteTypeName.indexOf(x.name) != -1 && x.generics.length == 0 && x.array.length == 1 && x.array[0].dimensions == 1) {
+        return CsTypeCategory.ByteArray;
+    }
 
-  const categories: TypeCategory[] = [
-    {
-      category: CsTypeCategory.Enumerable,
-      types: [
-        "List",
-        "ObservableCollection",
-        "Array",
-        "IEnumerable",
-        "IList",
-        "IReadOnlyList",
-        "Collection",
-        "ICollection",
-        "ISet",
-        "HashSet",
-      ],
-      genericMin: 0,
-      genericMax: 1,
-    },
-    {
-      category: CsTypeCategory.Nullable,
-      types: ["Nullable", "System.Nullable"],
-      genericMin: 1,
-      genericMax: 1,
-    },
-    {
-      category: CsTypeCategory.Dictionary,
-      types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
-      genericMin: 2,
-      genericMax: 2,
-    },
-    {
-      category: CsTypeCategory.Boolean,
-      types: ["bool", "Boolean", "System.Boolean"],
-      genericMin: 0,
-      genericMax: 0,
-    },
-    {
-      category: CsTypeCategory.Number,
-      types: [
-        "int",
-        "Int32",
-        "System.Int32",
-        "float",
-        "Single",
-        "System.Single",
-        "double",
-        "Double",
-        "System.Double",
-        "decimal",
-        "Decimal",
-        "System.Decimal",
-        "long",
-        "Int64",
-        "System.Int64",
-        ...byteTypeName,
-        "sbyte",
-        "SByte",
-        "System.SByte",
-        "short",
-        "Int16",
-        "System.Int16",
-        "ushort",
-        "UInt16",
-        "System.UInt16",
-        "uint",
-        "UInt32",
-        "System.UInt32",
-        "ulong",
-        "UInt64",
-        "System.UInt64",
-      ],
-      genericMin: 0,
-      genericMax: 0,
-    },
-    {
-      category: CsTypeCategory.Date,
-      types: [
-        "DateTime",
-        "System.DateTime",
-        "DateTimeOffset",
-        "System.DateTimeOffset",
-      ],
-      genericMin: 0,
-      genericMax: 0,
-    },
-    {
-      category: CsTypeCategory.String,
-      types: ["Guid", "string", "System.String", "String"],
-      genericMin: 0,
-      genericMax: 0,
-    },
-    {
-      category: CsTypeCategory.Any,
-      types: ["object", "System.Object", "dynamic"],
-      genericMin: 0,
-      genericMax: 0,
-    },
-    {
-      category: CsTypeCategory.Task,
-      types: ["Task", "System.Threading.Tasks.Task"],
-      genericMin: 0,
-      genericMax: 1,
-    },
-    {
-      category: CsTypeCategory.Tuple,
-      types: ["Tuple", "System.Tuple"],
-      genericMin: 1,
-      genericMax: 1000,
-    },
-  ];
+    const categories: TypeCategory[] = [
+      {
+          category: CsTypeCategory.Enumerable,
+          types: ["List", "ObservableCollection", "Array", "IEnumerable", "IList", "IReadOnlyList", "Collection", "ICollection", "ISet", "HashSet"],
+          genericMin: 0,
+          genericMax: 1,
+      },
+      {
+          category: CsTypeCategory.Nullable,
+          types: ["Nullable", "System.Nullable"],
+          genericMin: 1,
+          genericMax: 1,
+      },
+      {
+          category: CsTypeCategory.Dictionary,
+          types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
+          genericMin: 2,
+          genericMax: 2,
+      },
+      {
+          category: CsTypeCategory.Boolean,
+          types: ["bool", "Boolean", "System.Boolean"],
+          genericMin: 0,
+          genericMax: 0,
+      },
+      {
+          category: CsTypeCategory.Number,
+          types: [
+              "int", "Int32", "System.Int32",
+              "float", "Single", "System.Single",
+              "double", "Double", "System.Double",
+              "decimal", "Decimal", "System.Decimal",
+              "long", "Int64", "System.Int64",
+              ...byteTypeName,
+              "sbyte", "SByte", "System.SByte",
+              "short", "Int16", "System.Int16",
+              "ushort", "UInt16", "System.UInt16",
+              "uint", "UInt32", "System.UInt32",
+              "ulong", "UInt64", "System.UInt64",
+          ],
+          genericMin: 0,
+          genericMax: 0,
+      },
+      {
+          category: CsTypeCategory.Date,
+          types: ["DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset"],
+          genericMin: 0,
+          genericMax: 0,
+      },
+      {
+          category: CsTypeCategory.String,
+          types: ["Guid", "string", "System.String", "String"],
+          genericMin: 0,
+          genericMax: 0,
+      },
+      {
+          category: CsTypeCategory.Any,
+          types: ["object", "System.Object", "dynamic"],
+          genericMin: 0,
+          genericMax: 0,
+      },
+      {
+          category: CsTypeCategory.Task,
+          types: ["Task", "System.Threading.Tasks.Task"],
+          genericMin: 0,
+          genericMax: 1,
+      },
+      {
+          category: CsTypeCategory.Tuple,
+          types: ["Tuple", "System.Tuple"],
+          genericMin: 1,
+          genericMax: 1000,
+      },
+    ];
 
-  const cat = categories.filter(
-    (cat) =>
-      cat.types.indexOf(x.name) != -1 &&
-      x.generics.length >= cat.genericMin &&
-      x.generics.length <= cat.genericMax
-  )[0];
-  return cat ? cat.category : CsTypeCategory.Other;
+    const cat = categories.filter(cat => cat.types.indexOf(x.name) != -1 && x.generics.length >= cat.genericMin && x.generics.length <= cat.genericMax)[0];
+    return cat ? cat.category : CsTypeCategory.Other;
 }
 
-export function convertToTypescript(
-  x: CsType,
-  config: ExtensionConfig
-): string {
-  if (
-    config.byteArrayToString &&
-    getTypeCategory(x) == CsTypeCategory.ByteArray
-  ) {
-    return "string";
-  }
-
-  var arrayStr = "";
-  for (var a of x.array) {
-    arrayStr += "[";
-    for (var i = 1; i < a.dimensions; i++) {
-      arrayStr += ",";
+export function convertToTypescript(x: CsType, config: ExtensionConfig): string {
+    if (config.byteArrayToString && getTypeCategory(x) == CsTypeCategory.ByteArray) {
+        return "string";
     }
-    arrayStr += "]";
-  }
-  return convertToTypescriptNoArray(x, config) + arrayStr;
+
+    var arrayStr = "";
+    for (var a of x.array) {
+        arrayStr += "[";
+        for (var i = 1; i < a.dimensions; i++) {
+            arrayStr += ",";
+        }
+        arrayStr += "]";
+    }
+    return convertToTypescriptNoArray(x, config) + arrayStr;
 }
-function convertToTypescriptNoArray(
-  value: CsType,
-  config: ExtensionConfig
-): string {
-  const category = getTypeCategory(value);
-  switch (category) {
-    case CsTypeCategory.Enumerable: {
-      if (value.generics.length == 0) {
-        return "any[]";
-      } else if (value.generics.length == 1) {
-        return convertToTypescript(value.generics[0], config) + "[]";
-      } else {
-        throw "";
-      }
-    }
 
-    case CsTypeCategory.Dictionary: {
-      let keyType =
-        getTypeCategory(value.generics[0]) == CsTypeCategory.Number
-          ? "number"
-          : "string";
-      if (config.dictionaryToRecord) {
-        return `Record<${keyType}, ${convertToTypescript(
-          value.generics[1],
-          config
-        )}>`;
-      }
-      return `{ [key: ${keyType}]: ${convertToTypescript(
-        value.generics[1],
-        config
-      )} }`;
+function convertToTypescriptNoArray(value: CsType, config: ExtensionConfig): string {
+    const category = getTypeCategory(value);
+    switch (category) {
+        case CsTypeCategory.Enumerable: {
+            if (value.generics.length == 0) {
+                return "any[]";
+            } else if (value.generics.length == 1) {
+                return convertToTypescript(value.generics[0], config) + "[]";
+            } else {
+                throw "";
+            }
+        }
+
+        case CsTypeCategory.Dictionary: {
+            let keyType = getTypeCategory(value.generics[0]) == CsTypeCategory.Number ? "number" : "string";
+            if (config.dictionaryToRecord) {
+                return `Record<${keyType}, ${convertToTypescript(value.generics[1], config)}>`;
+            }
+            return `{ [key: ${keyType}]: ${convertToTypescript(value.generics[1], config)} }`;
+        }
+        case CsTypeCategory.Nullable: {
+            return `${convertToTypescript(value.generics[0], config)} | null`;
+        }
+        case CsTypeCategory.Tuple: {
+            let x: { Item1: number; Item2: boolean };
+            let tupleElements = value.generics.map((v, i) => `Item${i + 1}: ${convertToTypescript(v, config)}`);
+            let join = tupleElements.reduce((a, b) => (a ? a + ", " + b : b), "");
+            return `{ ${join} }`;
+        }
+        case CsTypeCategory.Task: {
+            const promLike = (t: string) => "Promise<" + t + ">";
+            return value.generics.length == 0 ? promLike("void") : promLike(convertToTypescript(value.generics[0], config));
+        }
+        case CsTypeCategory.Boolean: {
+            return "boolean";
+        }
+        case CsTypeCategory.Number:
+        case CsTypeCategory.ByteArray: {
+            return "number";
+        }
+        case CsTypeCategory.Date: {
+            return config.dateToDateOrString ? "Date | string" : "Date";
+        }
+        case CsTypeCategory.String: {
+            return "string";
+        }
+        case CsTypeCategory.Any: {
+            return "any";
+        }
+        case CsTypeCategory.Other: {
+            const fullname = value.namespace + value.name;
+            if (value.generics.length > 0) {
+                var generics = value.generics.map((x) => convertToTypescript(x, config)).reduce((a, b) => (a ? a + ", " + b : b), "");
+                return `${fullname}<${generics}>`;
+            } else {
+                return fullname;
+            }
+        }
     }
-    case CsTypeCategory.Nullable: {
-      return `${convertToTypescript(value.generics[0], config)} | null`;
-    }
-    case CsTypeCategory.Tuple: {
-      let x: { Item1: number; Item2: boolean };
-      let tupleElements = value.generics.map(
-        (v, i) => `Item${i + 1}: ${convertToTypescript(v, config)}`
-      );
-      let join = tupleElements.reduce((a, b) => (a ? a + ", " + b : b), "");
-      return `{ ${join} }`;
-    }
-    case CsTypeCategory.Task: {
-      const promLike = (t: string) => "Promise<" + t + ">";
-      return value.generics.length == 0
-        ? promLike("void")
-        : promLike(convertToTypescript(value.generics[0], config));
-    }
-    case CsTypeCategory.Boolean: {
-      return "boolean";
-    }
-    case CsTypeCategory.Number:
-    case CsTypeCategory.ByteArray: {
-      return "number";
-    }
-    case CsTypeCategory.Date: {
-      return config.dateToDateOrString ? "Date | string" : "Date";
-    }
-    case CsTypeCategory.String: {
-      return "string";
-    }
-    case CsTypeCategory.Any: {
-      return "any";
-    }
-    case CsTypeCategory.Other: {
-      const fullname = value.namespace + value.name;
-      if (value.generics.length > 0) {
-        var generics = value.generics
-          .map((x) => convertToTypescript(x, config))
-          .reduce((a, b) => (a ? a + ", " + b : b), "");
-        return `${fullname}<${generics}>`;
-      } else {
-        return fullname;
-      }
-    }
-  }
 }
 
 /**A c# array */
 interface CsArray {
-  /**Array dimensions */
-  dimensions: number;
+    /**Array dimensions */
+    dimensions: number;
 }
 
-/**Split on top level by a given separator, separators inside < >, [ ], { } or ( ) groups are not considered
- *
+/**
+ * Split on top level by a given separator, separators inside < >, [ ], { } or ( ) groups are not considered
  * @param separator One char separators
  */
-export function splitTopLevel(
-  text: string,
-  separators: string[],
-  openGroup: string[] = ["[", "(", "<", "{"],
-  closeGroup: string[] = ["]", ")", ">", "}"]
-): string[] {
-  var ret: string[] = [];
-  var level = 0;
-  var current = "";
-  for (let i = 0; i < text.length; i++) {
-    let char = text.charAt(i);
-    if (openGroup.indexOf(char) != -1) {
-      level++;
-    }
-    if (closeGroup.indexOf(char) != -1) {
-      level--;
-    }
+export function splitTopLevel(text: string, separators: string[], openGroup: string[] = ["[", "(", "<", "{"], closeGroup: string[] = ["]", ")", ">", "}"]): string[] {
+    var ret: string[] = [];
+    var level = 0;
+    var current = "";
+    for (let i = 0; i < text.length; i++) {
+        let char = text.charAt(i);
+        if (openGroup.indexOf(char) != -1) {
+            level++;
+        }
+        if (closeGroup.indexOf(char) != -1) {
+            level--;
+        }
 
-    if (level == 0 && separators.indexOf(char) != -1) {
-      ret.push(current);
-      current = "";
-    } else {
-      current += char;
+        if (level == 0 && separators.indexOf(char) != -1) {
+            ret.push(current);
+            current = "";
+        } else {
+            current += char;
+        }
     }
-  }
-  if (current != "") ret.push(current);
-  return ret;
+    if (current != "")
+        ret.push(current);
+    return ret;
 }
 
 /**Split on top level commas */
 function splitCommas(text: string): string[] {
-  return splitTopLevel(text, [","]);
+    return splitTopLevel(text, [","]);
 }
 
 /**Parse an array definition */
 function parseArray(code: string): CsArray[] {
-  let ret: CsArray[] = [];
-  for (let i = 0; i < code.length; i++) {
-    let char = code.charAt(i);
-    if (char == "[") {
-      ret.push({ dimensions: 1 });
+    let ret: CsArray[] = [];
+    for (let i = 0; i < code.length; i++) {
+        let char = code.charAt(i);
+        if (char == "[") {
+            ret.push({ dimensions: 1 });
+        }
+        if (char == "," && ret.length) {
+            ret[ret.length - 1].dimensions++;
+        }
     }
-    if (char == "," && ret.length) {
-      ret[ret.length - 1].dimensions++;
-    }
-  }
-  return ret;
+    return ret;
 }
 
 /**Parse a C# type, returns null if the given type could not be parsed */
 export function parseType(code: string): CsType | null {
-  //Remove all spaces:
-  code = code.replace(" ", "");
+    //Remove all spaces:
+    code = code.replace(" ", "");
 
-  const patt = seq(
-    cap(namespaceRegex),
-    cap(identifier),
-    spaceOptional,
-    optional(/<(.*)>/),
-    spaceOptional,
-    cap(optional(/\?/)),
-    spaceOptional,
-    zeroOrMore(cap(/\[[,\[\]]*\]/))
-  );
+    const patt = seq(
+        cap(namespaceRegex),
+        cap(identifier),
+        spaceOptional,
+        optional(/<(.*)>/),
+        spaceOptional,
+        cap(optional(/\?/)),
+        spaceOptional,
+        zeroOrMore(cap(/\[[,\[\]]*\]/))
+    );
 
-  const arr = patt.exec(code);
-  if (!arr) {
-    return null;
-  }
+    const arr = patt.exec(code);
+    if (!arr) {
+        return null;
+    }
 
-  //Pattern groups:
-  const namespace = arr[1];
-  const name = arr[2];
-  const genericsStr = splitCommas(arr[3] || "");
-  const nullable = arr[4] == "?";
-  const arraysStr = arr[5] || "";
+    //Pattern groups:
+    const namespace = arr[1];
+    const name = arr[2];
+    const genericsStr = splitCommas(arr[3] || "");
+    const nullable = arr[4] == "?";
+    const arraysStr = arr[5] || "";
 
-  const arrays = parseArray(arraysStr);
-  const genericsOrNull = genericsStr.map((x) => parseType(x));
-  const genericParseError = genericsOrNull.filter((x) => x == null).length > 0;
+    const arrays = parseArray(arraysStr);
+    const genericsOrNull = genericsStr.map((x) => parseType(x));
+    const genericParseError = genericsOrNull.filter((x) => x == null).length > 0;
 
-  if (genericParseError) return null;
-  const generics = genericsOrNull.map((x) => x!);
+    if (genericParseError) return null;
+    const generics = genericsOrNull.map((x) => x!);
 
-  if (nullable) {
-    var underlyingType = { namespace: "", name, generics, array: [] };
-    return {
-      namespace: "",
-      name: "Nullable",
-      generics: [underlyingType],
-      array: arrays,
-    };
-  } else {
-    return { name, generics, array: arrays, namespace: namespace };
-  }
+    if (nullable) {
+        var underlyingType = { namespace: "", name, generics, array: [] };
+        return {
+            namespace: "",
+            name: "Nullable",
+            generics: [underlyingType],
+            array: arrays,
+        };
+    } else {
+        return { name, generics, array: arrays, namespace: namespace };
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,27 +79,23 @@ export function getTypeCategory(x: CsType): CsTypeCategory {
             category: CsTypeCategory.Enumerable,
             types: ["List", "ObservableCollection", "Array", "IEnumerable", "IList", "IReadOnlyList", "Collection", "ICollection", "ISet", "HashSet"],
             genericMin: 0,
-            genericMax: 1,
-        },
-        {
+            genericMax: 1
+        }, {
             category: CsTypeCategory.Nullable,
             types: ["Nullable", "System.Nullable"],
             genericMin: 1,
-            genericMax: 1,
-        },
-        {
+            genericMax: 1
+        }, {
             category: CsTypeCategory.Dictionary,
             types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
             genericMin: 2,
-            genericMax: 2,
-        },
-        {
+            genericMax: 2
+        }, {
             category: CsTypeCategory.Boolean,
             types: ["bool", "Boolean", "System.Boolean"],
             genericMin: 0,
-            genericMax: 0,
-        },
-        {
+            genericMax: 0
+        }, {
             category: CsTypeCategory.Number,
             types: [
                 "int", "Int32", "System.Int32",
@@ -112,40 +108,35 @@ export function getTypeCategory(x: CsType): CsTypeCategory {
                 "short", "Int16", "System.Int16",
                 "ushort", "UInt16", "System.UInt16",
                 "uint", "UInt32", "System.UInt32",
-                "ulong", "UInt64", "System.UInt64",
+                "ulong", "UInt64", "System.UInt64"
             ],
             genericMin: 0,
-            genericMax: 0,
-        },
-        {
+            genericMax: 0
+        }, {
             category: CsTypeCategory.Date,
             types: ["DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset"],
             genericMin: 0,
-            genericMax: 0,
-        },
-        {
+            genericMax: 0
+        }, {
             category: CsTypeCategory.String,
             types: ["Guid", "string", "System.String", "String"],
             genericMin: 0,
-            genericMax: 0,
-        },
-        {
+            genericMax: 0
+        }, {
             category: CsTypeCategory.Any,
             types: ["object", "System.Object", "dynamic"],
             genericMin: 0,
-            genericMax: 0,
-        },
-        {
+            genericMax: 0
+        }, {
             category: CsTypeCategory.Task,
             types: ["Task", "System.Threading.Tasks.Task"],
             genericMin: 0,
-            genericMax: 1,
-        },
-        {
+            genericMax: 1
+        }, {
             category: CsTypeCategory.Tuple,
             types: ["Tuple", "System.Tuple"],
             genericMin: 1,
-            genericMax: 1000,
+            genericMax: 1000
         },
     ];
 
@@ -325,7 +316,7 @@ export function parseType(code: string): CsType | null {
             namespace: "",
             name: "Nullable",
             generics: [underlyingType],
-            array: arrays,
+            array: arrays
         };
     } else {
         return { name, generics, array: arrays, namespace: namespace };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,324 +1,423 @@
-
-import { any, cap, nonCap, oneOrMore, optional, seq, zeroOrMore } from "./compose";
-import { identifier, namespace as namespaceRegex, space, spaceOptional } from "./regexs";
+import {
+  any,
+  cap,
+  nonCap,
+  oneOrMore,
+  optional,
+  seq,
+  zeroOrMore,
+} from "./compose";
+import {
+  identifier,
+  namespace as namespaceRegex,
+  space,
+  spaceOptional,
+} from "./regexs";
 import { ExtensionConfig } from "./config";
 
 enum CsTypeCategory {
-    /**A type that can be represented as a collection of items */
-    Enumerable,
-    /**A dictionary is equivalent to a typescript object */
-    Dictionary,
-    /**A c$# nullable type where the value type is the first generic type */
-    Nullable,
-    /**A c# tuple */
-    Tuple,
-    /**A boolean type */
-    Boolean,
-    /**A numeric type */
-    Number,
-    /**A 1-dimension byte array */
-    ByteArray,
-    /**A date type */
-    Date,
-    /**A string type */
-    String,
-    /**Any type */
-    Any,
-    /**Unidentified type */
-    Other,
-    /**Task/promise task */
-    Task
+  /**A type that can be represented as a collection of items */
+  Enumerable,
+  /**A dictionary is equivalent to a typescript object */
+  Dictionary,
+  /**A c$# nullable type where the value type is the first generic type */
+  Nullable,
+  /**A c# tuple */
+  Tuple,
+  /**A boolean type */
+  Boolean,
+  /**A numeric type */
+  Number,
+  /**A 1-dimension byte array */
+  ByteArray,
+  /**A date type */
+  Date,
+  /**A string type */
+  String,
+  /**Any type */
+  Any,
+  /**Unidentified type */
+  Other,
+  /**Task/promise task */
+  Task,
 }
 
 export interface CsType {
-    /**Type namespace */
-    namespace: string;
-    /**Type name */
-    name: string;
-    /**Generic arguments */
-    generics: CsType[];
+  /**Type namespace */
+  namespace: string;
+  /**Type name */
+  name: string;
+  /**Generic arguments */
+  generics: CsType[];
 
-    /**Neasted arrays */
-    array: CsArray[];
+  /**Neasted arrays */
+  array: CsArray[];
 }
 
 /**Check if the given type is a simple that that passes as an uri parameter */
 export function isUriSimpleType(x: CsType): boolean {
-    const simpleCats: CsTypeCategory[] = [
-        CsTypeCategory.Boolean,
-        CsTypeCategory.Number,
-        CsTypeCategory.Date,
-        CsTypeCategory.String,
-    ];
+  const simpleCats: CsTypeCategory[] = [
+    CsTypeCategory.Boolean,
+    CsTypeCategory.Number,
+    CsTypeCategory.Date,
+    CsTypeCategory.String,
+  ];
 
-    const isSimpleCat = (x: CsTypeCategory) => simpleCats.indexOf(x) != -1;
-    const typeCat = getTypeCategory(x);
-    if (isSimpleCat(typeCat)) {
-        return true;
-    } else if (typeCat == CsTypeCategory.Nullable && isSimpleCat(getTypeCategory(x.generics[0]))) {
-        return true;
-    }
-    return false;
+  const isSimpleCat = (x: CsTypeCategory) => simpleCats.indexOf(x) != -1;
+  const typeCat = getTypeCategory(x);
+  if (isSimpleCat(typeCat)) {
+    return true;
+  } else if (
+    typeCat == CsTypeCategory.Nullable &&
+    isSimpleCat(getTypeCategory(x.generics[0]))
+  ) {
+    return true;
+  }
+  return false;
 }
 
 export function getTypeCategory(x: CsType): CsTypeCategory {
-    type TypeCategory = {
-        category: CsTypeCategory;
-        types: string[];
-        genericMin: number;
-        genericMax: number
-    };
-    const byteTypeName = ['byte', "Byte", "System.Byte"];
+  type TypeCategory = {
+    category: CsTypeCategory;
+    types: string[];
+    genericMin: number;
+    genericMax: number;
+  };
+  const byteTypeName = ["byte", "Byte", "System.Byte"];
 
-    //Check if the type is byteArray
-    if (byteTypeName.indexOf(x.name) != -1 && x.generics.length == 0 && x.array.length == 1 && x.array[0].dimensions == 1) {
-        return CsTypeCategory.ByteArray;
-    }
+  //Check if the type is byteArray
+  if (
+    byteTypeName.indexOf(x.name) != -1 &&
+    x.generics.length == 0 &&
+    x.array.length == 1 &&
+    x.array[0].dimensions == 1
+  ) {
+    return CsTypeCategory.ByteArray;
+  }
 
-    const categories: TypeCategory[] = [
-        {
-            category: CsTypeCategory.Enumerable,
-            types: ["List", "ObservableCollection", "Array", "IEnumerable", "IList", "IReadOnlyList", "Collection", "ICollection", "ISet", "HashSet"],
-            genericMin: 0,
-            genericMax: 1
-        }, {
-            category: CsTypeCategory.Nullable,
-            types: ["Nullable", "System.Nullable"],
-            genericMin: 1,
-            genericMax: 1
-        }, {
-            category: CsTypeCategory.Dictionary,
-            types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
-            genericMin: 2,
-            genericMax: 2
-        }, {
-            category: CsTypeCategory.Boolean,
-            types: ["bool", "Boolean", "System.Boolean"],
-            genericMin: 0,
-            genericMax: 0
-        }, {
-            category: CsTypeCategory.Number,
-            types: [
-                'int', "Int32", "System.Int32",
-                'float', "Single", "System.Single",
-                "double", "Double", "System.Double",
-                'decimal', "Decimal", "System.Decimal",
-                'long', "Int64", "System.Int64",
-                ...byteTypeName,
-                'sbyte', "SByte", "System.SByte",
-                'short', "Int16", "System.Int16",
-                'ushort', "UInt16", "System.UInt16",
-                'uint', "UInt32", "System.UInt32",
-                'ulong', "UInt64", "System.UInt64"
-            ],
-            genericMin: 0,
-            genericMax: 0
-        }, {
-            category: CsTypeCategory.Date,
-            types: ["DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset"],
-            genericMin: 0,
-            genericMax: 0
-        }, {
-            category: CsTypeCategory.String,
-            types: ["Guid", "string", "System.String", "String"],
-            genericMin: 0,
-            genericMax: 0,
-        }, {
-            category: CsTypeCategory.Any,
-            types: ["object", "System.Object", "dynamic"],
-            genericMin: 0,
-            genericMax: 0,
-        }, {
-            category: CsTypeCategory.Task,
-            types: ["Task", "System.Threading.Tasks.Task"],
-            genericMin: 0,
-            genericMax: 1
-        }, {
-            category: CsTypeCategory.Tuple,
-            types: ["Tuple", "System.Tuple"],
-            genericMin: 1,
-            genericMax: 1000
-        }
-    ];
+  const categories: TypeCategory[] = [
+    {
+      category: CsTypeCategory.Enumerable,
+      types: [
+        "List",
+        "ObservableCollection",
+        "Array",
+        "IEnumerable",
+        "IList",
+        "IReadOnlyList",
+        "Collection",
+        "ICollection",
+        "ISet",
+        "HashSet",
+      ],
+      genericMin: 0,
+      genericMax: 1,
+    },
+    {
+      category: CsTypeCategory.Nullable,
+      types: ["Nullable", "System.Nullable"],
+      genericMin: 1,
+      genericMax: 1,
+    },
+    {
+      category: CsTypeCategory.Dictionary,
+      types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
+      genericMin: 2,
+      genericMax: 2,
+    },
+    {
+      category: CsTypeCategory.Boolean,
+      types: ["bool", "Boolean", "System.Boolean"],
+      genericMin: 0,
+      genericMax: 0,
+    },
+    {
+      category: CsTypeCategory.Number,
+      types: [
+        "int",
+        "Int32",
+        "System.Int32",
+        "float",
+        "Single",
+        "System.Single",
+        "double",
+        "Double",
+        "System.Double",
+        "decimal",
+        "Decimal",
+        "System.Decimal",
+        "long",
+        "Int64",
+        "System.Int64",
+        ...byteTypeName,
+        "sbyte",
+        "SByte",
+        "System.SByte",
+        "short",
+        "Int16",
+        "System.Int16",
+        "ushort",
+        "UInt16",
+        "System.UInt16",
+        "uint",
+        "UInt32",
+        "System.UInt32",
+        "ulong",
+        "UInt64",
+        "System.UInt64",
+      ],
+      genericMin: 0,
+      genericMax: 0,
+    },
+    {
+      category: CsTypeCategory.Date,
+      types: [
+        "DateTime",
+        "System.DateTime",
+        "DateTimeOffset",
+        "System.DateTimeOffset",
+      ],
+      genericMin: 0,
+      genericMax: 0,
+    },
+    {
+      category: CsTypeCategory.String,
+      types: ["Guid", "string", "System.String", "String"],
+      genericMin: 0,
+      genericMax: 0,
+    },
+    {
+      category: CsTypeCategory.Any,
+      types: ["object", "System.Object", "dynamic"],
+      genericMin: 0,
+      genericMax: 0,
+    },
+    {
+      category: CsTypeCategory.Task,
+      types: ["Task", "System.Threading.Tasks.Task"],
+      genericMin: 0,
+      genericMax: 1,
+    },
+    {
+      category: CsTypeCategory.Tuple,
+      types: ["Tuple", "System.Tuple"],
+      genericMin: 1,
+      genericMax: 1000,
+    },
+  ];
 
-    const cat = categories.filter(cat => cat.types.indexOf(x.name) != -1 && x.generics.length >= cat.genericMin && x.generics.length <= cat.genericMax)[0];
-    return cat ? cat.category : CsTypeCategory.Other;
+  const cat = categories.filter(
+    (cat) =>
+      cat.types.indexOf(x.name) != -1 &&
+      x.generics.length >= cat.genericMin &&
+      x.generics.length <= cat.genericMax
+  )[0];
+  return cat ? cat.category : CsTypeCategory.Other;
 }
 
-export function convertToTypescript(x: CsType, config: ExtensionConfig): string {
-    if(config.byteArrayToString && getTypeCategory(x) ==  CsTypeCategory.ByteArray) {
-        return "string";
-    }
+export function convertToTypescript(
+  x: CsType,
+  config: ExtensionConfig
+): string {
+  if (
+    config.byteArrayToString &&
+    getTypeCategory(x) == CsTypeCategory.ByteArray
+  ) {
+    return "string";
+  }
 
-    var arrayStr = "";
-    for (var a of x.array) {
-        arrayStr += "[";
-        for (var i = 1; i < a.dimensions; i++) {
-            arrayStr += ",";
-        }
-        arrayStr += "]";
+  var arrayStr = "";
+  for (var a of x.array) {
+    arrayStr += "[";
+    for (var i = 1; i < a.dimensions; i++) {
+      arrayStr += ",";
     }
-    return convertToTypescriptNoArray(x, config) + arrayStr;
+    arrayStr += "]";
+  }
+  return convertToTypescriptNoArray(x, config) + arrayStr;
 }
-function convertToTypescriptNoArray(value: CsType, config: ExtensionConfig): string {
-    const category = getTypeCategory(value);
-    switch (category) {
-        case CsTypeCategory.Enumerable: {
-            if (value.generics.length == 0) {
-                return "any[]";
-            } else if (value.generics.length == 1) {
-                return convertToTypescript(value.generics[0], config) + "[]";
-            } else {
-                throw "";
-            }
-        }
-
-        case CsTypeCategory.Dictionary: {
-            let keyType = (getTypeCategory(value.generics[0]) == CsTypeCategory.Number) ? "number" : "string";
-            return `{ [key: ${keyType}]: ${convertToTypescript(value.generics[1], config)} }`;
-
-        }
-        case CsTypeCategory.Nullable: {
-            return `${convertToTypescript(value.generics[0], config)} | null`;
-        }
-        case CsTypeCategory.Tuple: {
-            let x: { Item1: number, Item2: boolean };
-            let tupleElements = value.generics.map((v, i) => `Item${i + 1}: ${convertToTypescript(v, config)}`);
-            let join = tupleElements.reduce((a, b) => a ? a + ", " + b : b, "");
-            return `{ ${join} }`;
-        }
-        case CsTypeCategory.Task: {
-            const promLike = (t: string) => "Promise<" + t + ">";
-            return value.generics.length == 0 ? promLike("void") : promLike(convertToTypescript(value.generics[0], config));
-        }
-        case CsTypeCategory.Boolean: {
-            return "boolean";
-        }
-        case CsTypeCategory.Number:
-        case CsTypeCategory.ByteArray: {
-            return "number";
-        }
-        case CsTypeCategory.Date: {
-            return config.dateToDateOrString ? "Date | string"  : "Date";
-        }
-        case CsTypeCategory.String: {
-            return "string";
-        }
-        case CsTypeCategory.Any: {
-            return "any";
-        }
-        case CsTypeCategory.Other: {
-            const fullname = value.namespace + value.name;
-            if (value.generics.length > 0) {
-                var generics = value.generics.map(x => convertToTypescript(x, config)).reduce((a, b) => a ? a + ", " + b : b, "");
-                return `${fullname}<${generics}>`;
-            } else {
-                return fullname;
-            }
-        }
+function convertToTypescriptNoArray(
+  value: CsType,
+  config: ExtensionConfig
+): string {
+  const category = getTypeCategory(value);
+  switch (category) {
+    case CsTypeCategory.Enumerable: {
+      if (value.generics.length == 0) {
+        return "any[]";
+      } else if (value.generics.length == 1) {
+        return convertToTypescript(value.generics[0], config) + "[]";
+      } else {
+        throw "";
+      }
     }
+
+    case CsTypeCategory.Dictionary: {
+      let keyType =
+        getTypeCategory(value.generics[0]) == CsTypeCategory.Number
+          ? "number"
+          : "string";
+      if (config.dictionaryToRecord) {
+        return `Record<${keyType}, ${convertToTypescript(
+          value.generics[1],
+          config
+        )}>`;
+      }
+      return `{ [key: ${keyType}]: ${convertToTypescript(
+        value.generics[1],
+        config
+      )} }`;
+    }
+    case CsTypeCategory.Nullable: {
+      return `${convertToTypescript(value.generics[0], config)} | null`;
+    }
+    case CsTypeCategory.Tuple: {
+      let x: { Item1: number; Item2: boolean };
+      let tupleElements = value.generics.map(
+        (v, i) => `Item${i + 1}: ${convertToTypescript(v, config)}`
+      );
+      let join = tupleElements.reduce((a, b) => (a ? a + ", " + b : b), "");
+      return `{ ${join} }`;
+    }
+    case CsTypeCategory.Task: {
+      const promLike = (t: string) => "Promise<" + t + ">";
+      return value.generics.length == 0
+        ? promLike("void")
+        : promLike(convertToTypescript(value.generics[0], config));
+    }
+    case CsTypeCategory.Boolean: {
+      return "boolean";
+    }
+    case CsTypeCategory.Number:
+    case CsTypeCategory.ByteArray: {
+      return "number";
+    }
+    case CsTypeCategory.Date: {
+      return config.dateToDateOrString ? "Date | string" : "Date";
+    }
+    case CsTypeCategory.String: {
+      return "string";
+    }
+    case CsTypeCategory.Any: {
+      return "any";
+    }
+    case CsTypeCategory.Other: {
+      const fullname = value.namespace + value.name;
+      if (value.generics.length > 0) {
+        var generics = value.generics
+          .map((x) => convertToTypescript(x, config))
+          .reduce((a, b) => (a ? a + ", " + b : b), "");
+        return `${fullname}<${generics}>`;
+      } else {
+        return fullname;
+      }
+    }
+  }
 }
 
 /**A c# array */
 interface CsArray {
-    /**Array dimensions */
-    dimensions: number;
+  /**Array dimensions */
+  dimensions: number;
 }
 
 /**Split on top level by a given separator, separators inside < >, [ ], { } or ( ) groups are not considered
- * 
+ *
  * @param separator One char separators
  */
-export function splitTopLevel(text: string, separators: string[], openGroup: string[] = ["[", "(", "<", "{"], closeGroup: string[] = ["]", ")", ">", "}"]): string[] {
-    var ret: string[] = [];
-    var level = 0;
-    var current = "";
-    for (let i = 0; i < text.length; i++) {
-        let char = text.charAt(i);
-        if (openGroup.indexOf(char) != -1) {
-            level++;
-        }
-        if (closeGroup.indexOf(char) != -1) {
-            level--;
-        }
-
-        if (level == 0 && separators.indexOf(char) != -1) {
-            ret.push(current);
-            current = "";
-        } else {
-            current += char;
-        }
+export function splitTopLevel(
+  text: string,
+  separators: string[],
+  openGroup: string[] = ["[", "(", "<", "{"],
+  closeGroup: string[] = ["]", ")", ">", "}"]
+): string[] {
+  var ret: string[] = [];
+  var level = 0;
+  var current = "";
+  for (let i = 0; i < text.length; i++) {
+    let char = text.charAt(i);
+    if (openGroup.indexOf(char) != -1) {
+      level++;
     }
-    if (current != "")
-        ret.push(current);
-    return ret;
+    if (closeGroup.indexOf(char) != -1) {
+      level--;
+    }
+
+    if (level == 0 && separators.indexOf(char) != -1) {
+      ret.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current != "") ret.push(current);
+  return ret;
 }
 
 /**Split on top level commas */
 function splitCommas(text: string): string[] {
-    return splitTopLevel(text, [","]);
+  return splitTopLevel(text, [","]);
 }
 
 /**Parse an array definition */
 function parseArray(code: string): CsArray[] {
-    let ret: CsArray[] = [];
-    for (let i = 0; i < code.length; i++) {
-        let char = code.charAt(i);
-        if (char == "[") {
-            ret.push({ dimensions: 1 });
-        }
-        if (char == "," && ret.length) {
-            ret[ret.length - 1].dimensions++;
-        }
+  let ret: CsArray[] = [];
+  for (let i = 0; i < code.length; i++) {
+    let char = code.charAt(i);
+    if (char == "[") {
+      ret.push({ dimensions: 1 });
     }
-    return ret;
+    if (char == "," && ret.length) {
+      ret[ret.length - 1].dimensions++;
+    }
+  }
+  return ret;
 }
 
 /**Parse a C# type, returns null if the given type could not be parsed */
 export function parseType(code: string): CsType | null {
-    //Remove all spaces:
-    code = code.replace(" ", "");
+  //Remove all spaces:
+  code = code.replace(" ", "");
 
-    const patt = seq(
-        cap(namespaceRegex),
-        cap(identifier),
-        spaceOptional,
-        optional(/<(.*)>/),
-        spaceOptional,
-        cap(optional(/\?/)),
-        spaceOptional,
-        zeroOrMore(cap(/\[[,\[\]]*\]/))
-    );
+  const patt = seq(
+    cap(namespaceRegex),
+    cap(identifier),
+    spaceOptional,
+    optional(/<(.*)>/),
+    spaceOptional,
+    cap(optional(/\?/)),
+    spaceOptional,
+    zeroOrMore(cap(/\[[,\[\]]*\]/))
+  );
 
-    const arr = patt.exec(code);
-    if (!arr) {
-        return null;
-    }
+  const arr = patt.exec(code);
+  if (!arr) {
+    return null;
+  }
 
-    //Pattern groups:
-    const namespace = arr[1];
-    const name = arr[2];
-    const genericsStr = splitCommas(arr[3] || "");
-    const nullable = arr[4] == "?";
-    const arraysStr = arr[5] || "";
+  //Pattern groups:
+  const namespace = arr[1];
+  const name = arr[2];
+  const genericsStr = splitCommas(arr[3] || "");
+  const nullable = arr[4] == "?";
+  const arraysStr = arr[5] || "";
 
-    const arrays = parseArray(arraysStr);
-    const genericsOrNull = genericsStr.map(x => parseType(x));
-    const genericParseError = genericsOrNull.filter(x => x == null).length > 0;
+  const arrays = parseArray(arraysStr);
+  const genericsOrNull = genericsStr.map((x) => parseType(x));
+  const genericParseError = genericsOrNull.filter((x) => x == null).length > 0;
 
-    if (genericParseError) return null;
-    const generics = genericsOrNull.map(x => x!);
+  if (genericParseError) return null;
+  const generics = genericsOrNull.map((x) => x!);
 
-
-    if (nullable) {
-        var underlyingType = { namespace: "", name, generics, array: [] };
-        return {
-            namespace: "",
-            name: "Nullable",
-            generics: [underlyingType],
-            array: arrays
-        };
-    } else {
-        return { name, generics, array: arrays, namespace: namespace }
-    }
+  if (nullable) {
+    var underlyingType = { namespace: "", name, generics, array: [] };
+    return {
+      namespace: "",
+      name: "Nullable",
+      generics: [underlyingType],
+      array: arrays,
+    };
+  } else {
+    return { name, generics, array: arrays, namespace: namespace };
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ enum CsTypeCategory {
     /**Unidentified type */
     Other,
     /**Task/promise task */
-    Task,
+    Task
 }
 
 export interface CsType {
@@ -75,78 +75,78 @@ export function getTypeCategory(x: CsType): CsTypeCategory {
     }
 
     const categories: TypeCategory[] = [
-      {
-          category: CsTypeCategory.Enumerable,
-          types: ["List", "ObservableCollection", "Array", "IEnumerable", "IList", "IReadOnlyList", "Collection", "ICollection", "ISet", "HashSet"],
-          genericMin: 0,
-          genericMax: 1,
-      },
-      {
-          category: CsTypeCategory.Nullable,
-          types: ["Nullable", "System.Nullable"],
-          genericMin: 1,
-          genericMax: 1,
-      },
-      {
-          category: CsTypeCategory.Dictionary,
-          types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
-          genericMin: 2,
-          genericMax: 2,
-      },
-      {
-          category: CsTypeCategory.Boolean,
-          types: ["bool", "Boolean", "System.Boolean"],
-          genericMin: 0,
-          genericMax: 0,
-      },
-      {
-          category: CsTypeCategory.Number,
-          types: [
-              "int", "Int32", "System.Int32",
-              "float", "Single", "System.Single",
-              "double", "Double", "System.Double",
-              "decimal", "Decimal", "System.Decimal",
-              "long", "Int64", "System.Int64",
-              ...byteTypeName,
-              "sbyte", "SByte", "System.SByte",
-              "short", "Int16", "System.Int16",
-              "ushort", "UInt16", "System.UInt16",
-              "uint", "UInt32", "System.UInt32",
-              "ulong", "UInt64", "System.UInt64",
-          ],
-          genericMin: 0,
-          genericMax: 0,
-      },
-      {
-          category: CsTypeCategory.Date,
-          types: ["DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset"],
-          genericMin: 0,
-          genericMax: 0,
-      },
-      {
-          category: CsTypeCategory.String,
-          types: ["Guid", "string", "System.String", "String"],
-          genericMin: 0,
-          genericMax: 0,
-      },
-      {
-          category: CsTypeCategory.Any,
-          types: ["object", "System.Object", "dynamic"],
-          genericMin: 0,
-          genericMax: 0,
-      },
-      {
-          category: CsTypeCategory.Task,
-          types: ["Task", "System.Threading.Tasks.Task"],
-          genericMin: 0,
-          genericMax: 1,
-      },
-      {
-          category: CsTypeCategory.Tuple,
-          types: ["Tuple", "System.Tuple"],
-          genericMin: 1,
-          genericMax: 1000,
-      },
+        {
+            category: CsTypeCategory.Enumerable,
+            types: ["List", "ObservableCollection", "Array", "IEnumerable", "IList", "IReadOnlyList", "Collection", "ICollection", "ISet", "HashSet"],
+            genericMin: 0,
+            genericMax: 1,
+        },
+        {
+            category: CsTypeCategory.Nullable,
+            types: ["Nullable", "System.Nullable"],
+            genericMin: 1,
+            genericMax: 1,
+        },
+        {
+            category: CsTypeCategory.Dictionary,
+            types: ["Dictionary", "IDictionary", "IReadOnlyDictionary"],
+            genericMin: 2,
+            genericMax: 2,
+        },
+        {
+            category: CsTypeCategory.Boolean,
+            types: ["bool", "Boolean", "System.Boolean"],
+            genericMin: 0,
+            genericMax: 0,
+        },
+        {
+            category: CsTypeCategory.Number,
+            types: [
+                "int", "Int32", "System.Int32",
+                "float", "Single", "System.Single",
+                "double", "Double", "System.Double",
+                "decimal", "Decimal", "System.Decimal",
+                "long", "Int64", "System.Int64",
+                ...byteTypeName,
+                "sbyte", "SByte", "System.SByte",
+                "short", "Int16", "System.Int16",
+                "ushort", "UInt16", "System.UInt16",
+                "uint", "UInt32", "System.UInt32",
+                "ulong", "UInt64", "System.UInt64",
+            ],
+            genericMin: 0,
+            genericMax: 0,
+        },
+        {
+            category: CsTypeCategory.Date,
+            types: ["DateTime", "System.DateTime", "DateTimeOffset", "System.DateTimeOffset"],
+            genericMin: 0,
+            genericMax: 0,
+        },
+        {
+            category: CsTypeCategory.String,
+            types: ["Guid", "string", "System.String", "String"],
+            genericMin: 0,
+            genericMax: 0,
+        },
+        {
+            category: CsTypeCategory.Any,
+            types: ["object", "System.Object", "dynamic"],
+            genericMin: 0,
+            genericMax: 0,
+        },
+        {
+            category: CsTypeCategory.Task,
+            types: ["Task", "System.Threading.Tasks.Task"],
+            genericMin: 0,
+            genericMax: 1,
+        },
+        {
+            category: CsTypeCategory.Tuple,
+            types: ["Tuple", "System.Tuple"],
+            genericMin: 1,
+            genericMax: 1000,
+        },
     ];
 
     const cat = categories.filter(cat => cat.types.indexOf(x.name) != -1 && x.generics.length >= cat.genericMin && x.generics.length <= cat.genericMax)[0];
@@ -181,9 +181,8 @@ function convertToTypescriptNoArray(value: CsType, config: ExtensionConfig): str
                 throw "";
             }
         }
-
         case CsTypeCategory.Dictionary: {
-            let keyType = getTypeCategory(value.generics[0]) == CsTypeCategory.Number ? "number" : "string";
+            let keyType = (getTypeCategory(value.generics[0]) == CsTypeCategory.Number) ? "number" : "string";
             if (config.dictionaryToRecord) {
                 return `Record<${keyType}, ${convertToTypescript(value.generics[1], config)}>`;
             }
@@ -193,9 +192,9 @@ function convertToTypescriptNoArray(value: CsType, config: ExtensionConfig): str
             return `${convertToTypescript(value.generics[0], config)} | null`;
         }
         case CsTypeCategory.Tuple: {
-            let x: { Item1: number; Item2: boolean };
+            let x: { Item1: number, Item2: boolean };
             let tupleElements = value.generics.map((v, i) => `Item${i + 1}: ${convertToTypescript(v, config)}`);
-            let join = tupleElements.reduce((a, b) => (a ? a + ", " + b : b), "");
+            let join = tupleElements.reduce((a, b) => a ? a + ", " + b : b, "");
             return `{ ${join} }`;
         }
         case CsTypeCategory.Task: {
@@ -221,7 +220,7 @@ function convertToTypescriptNoArray(value: CsType, config: ExtensionConfig): str
         case CsTypeCategory.Other: {
             const fullname = value.namespace + value.name;
             if (value.generics.length > 0) {
-                var generics = value.generics.map((x) => convertToTypescript(x, config)).reduce((a, b) => (a ? a + ", " + b : b), "");
+                var generics = value.generics.map(x => convertToTypescript(x, config)).reduce((a, b) => a ? a + ", " + b : b, "");
                 return `${fullname}<${generics}>`;
             } else {
                 return fullname;
@@ -314,11 +313,11 @@ export function parseType(code: string): CsType | null {
     const arraysStr = arr[5] || "";
 
     const arrays = parseArray(arraysStr);
-    const genericsOrNull = genericsStr.map((x) => parseType(x));
-    const genericParseError = genericsOrNull.filter((x) => x == null).length > 0;
+    const genericsOrNull = genericsStr.map(x => parseType(x));
+    const genericParseError = genericsOrNull.filter(x => x == null).length > 0;
 
     if (genericParseError) return null;
-    const generics = genericsOrNull.map((x) => x!);
+    const generics = genericsOrNull.map(x => x!);
 
     if (nullable) {
         var underlyingType = { namespace: "", name, generics, array: [] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,12 +121,12 @@ export function getTypeCategory(x: CsType): CsTypeCategory {
             category: CsTypeCategory.String,
             types: ["Guid", "string", "System.String", "String"],
             genericMin: 0,
-            genericMax: 0
+            genericMax: 0,
         }, {
             category: CsTypeCategory.Any,
             types: ["object", "System.Object", "dynamic"],
             genericMin: 0,
-            genericMax: 0
+            genericMax: 0,
         }, {
             category: CsTypeCategory.Task,
             types: ["Task", "System.Threading.Tasks.Task"],
@@ -137,7 +137,7 @@ export function getTypeCategory(x: CsType): CsTypeCategory {
             types: ["Tuple", "System.Tuple"],
             genericMin: 1,
             genericMax: 1000
-        },
+        }
     ];
 
     const cat = categories.filter(cat => cat.types.indexOf(x.name) != -1 && x.generics.length >= cat.genericMin && x.generics.length <= cat.genericMax)[0];


### PR DESCRIPTION
- Default function of the converter stays the same
- Added config option to convert a C# Dictionary into a Typescript `Record<keyType, viewModel>` instead of the default`{ [key: keyType]: viewModel }`
- Cleaned up comments
- Added missing version notes to readme
- Added new version notes to readme